### PR TITLE
Limit SibsPaymentCodePool concurrency to avoid restarts

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,3 +1,5 @@
+- Improvement: Limit SibsPaymentCodePool payment request creation concurrency to avoid restarts
+
 8.0.3 (17-08-2021)
 - Bug Fix: Save sibs importation filename as comment in payment transaction, as before in deprecated sibs transaction detail
 - Bug Fix: Save sibs processing date in payment transaction

--- a/src/main/java/org/fenixedu/treasury/domain/paymentcodes/integration/SibsPaymentCodePool.java
+++ b/src/main/java/org/fenixedu/treasury/domain/paymentcodes/integration/SibsPaymentCodePool.java
@@ -349,7 +349,7 @@ public class SibsPaymentCodePool extends SibsPaymentCodePool_Base implements ISi
     }
 
     @Atomic
-    private SibsPaymentRequest createPaymentRequest(DebtAccount debtAccount, Set<DebitEntry> debitEntries,
+    private synchronized SibsPaymentRequest createPaymentRequest(DebtAccount debtAccount, Set<DebitEntry> debitEntries,
             Set<Installment> installments, LocalDate validTo, BigDecimal payableAmount) {
 
         checkMaxActiveSibsPaymentRequests(debitEntries, installments);


### PR DESCRIPTION
Improvement: Limit SibsPaymentCodePool payment request creation concurrency to avoid restarts